### PR TITLE
プラグインcssパスが正しくない

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -32,7 +32,7 @@ License:
 
 function kattene_func( $args, $content ) {
 
-  $path = str_replace(home_url(),'',plugin_dir_url( __FILE__ ));
+  $path = str_replace(site_url(),'',plugin_dir_url( __FILE__ ));
   wp_enqueue_style( 'kattene', $path . 'style.css');
   do_action( 'kattene' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -73,7 +73,7 @@ function kattene_func( $args, $content ) {
   $str .= '</div>
     </div>
   </div>';
-  $path = str_replace(home_url(),'',plugin_dir_url( __FILE__ ));
+  $path = str_replace(site_url(),'',plugin_dir_url( __FILE__ ));
   wp_enqueue_style( 'kattene', $path . 'style.css');
 
   add_action( 'wp_footer', 'kattene_script' );

--- a/plugin.php
+++ b/plugin.php
@@ -69,7 +69,7 @@ function kattene_func( $args, $content ) {
   }
 
   $str .= '</div></div></div>';
-  $path = str_replace(home_url(),'',plugin_dir_url( __FILE__ ));
+  $path = str_replace(site_url(),'',plugin_dir_url( __FILE__ ));
   wp_enqueue_style( 'kattene', $path . 'style.css');
 
   add_action( 'wp_footer', 'kattene_script' );


### PR DESCRIPTION
はじめまして、便利なwordpressプラグインをありがとうございます。

私のwordpressにインストールして使ってみたところ、スタイルが適用されませんでした。

home_url()がhttps://example.jp
site_url()がhttps://example.jp/wordpress
のとき、プラグインcssパスは
https://example.jp/wordpress/plugins/kattene-master/style.css
となるはずですが、
https://example.jp/wordpress/wordpress/plugins/kattene-master/style.css
となっていました。

他のプラグインの影響かもしれませんが、
katteプラグインのplugin.phpの76行目を次のように修正したところ、スタイルが適用されました。

修正前
$path = str_replace(home_url(),'',plugin_dir_url( __FILE__ ));

プルリク案
$path = str_replace(site_url(),'',plugin_dir_url( __FILE__ ));

別の案
$path = plugin_dir_url( __FILE__ );

マージ、却下の判断はお任せします。